### PR TITLE
Split landing/about; rewrite landing

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,9 +1,7 @@
-# currently about is at index.md; uncomment if we have separate landing and
-# about
-#- name: About
-  #link: /about/
-  #new_window: False
-  #highlight: False
+- name: About
+  link: /about/
+  new_window: False
+  highlight: False
 - name: Our Team
   link: /team/
   new_window: False

--- a/about.md
+++ b/about.md
@@ -1,0 +1,32 @@
+---
+layout: page
+title: About Open Free Energy
+permalink: /about/
+description:
+---
+
+
+## Mission
+Promote, foster and advance science in Computational Biophysics through the
+development of precision-driven open software.
+
+## Vision
+By 2027, be the world reference in open molecular-software development.
+
+## Values
+
+**Skepticism:** There is no such thing as absolute or eternal truth.
+
+**Open-mindedness:** We are eager to accept different knowledge as it is built
+on facts, data and evidence.
+
+**Willingness to learn:** Science is a lifelong journey.  Passion for
+intellectual development: we build paths to enlightenment.
+
+## What we do?
+
+We believe in developing rational, science-based and sustainable open solutions
+to humanity’s problems. We do this by offering complete computational
+technologies aimed at building knowledge about biological systems of interest.
+Our goal is to support the pharmaceutical industry in the intelligent drug
+design process to enable innovative treatments for those who need them.

--- a/index.md
+++ b/index.md
@@ -9,43 +9,20 @@ description: >-
 
 ### OPEN SOURCE
 
-Software permissively licensed under the MIT License and [developed openly on
-GitHub](https://github.com/OpenFreeEnergy).
+Our software is [developed in public on
+GitHub](https://github.com/OpenFreeEnergy) and is released under the permissive
+MIT license.
 
 ### BINDING FREE ENERGY
 
-Thermodynamic quantity related to the spontaneity of a coupling process between
-biological macromolecules.
+We develop tools that enable our users to easily and efficiently calculate
+binding free energies for networks of molecular systems.
 
 ### DRUG DESIGN AND DISCOVERY
 
-Scientific process of rationally developing new drugs based on the knowledge
-about a biological target.
+Our tools are designed with the pharmaceutical lead optimization in mind, and
+we work closely with our board members in industry to develop tools that meet
+the needs of real-world users.
+
 
 OpenFE is hosted by the [Open Molecular Software Foundation](https://omsf.io).
-
-
-## Mission
-Promote, foster and advance science in Computational Biophysics through the
-development of precision-driven open software.
-
-## Vision
-By 2027, be the world reference in open molecular-software development.
-
-## Values
-
-**Skepticism:** There is no such thing as absolute or eternal truth.
-
-**Open-mindedness:** We are eager to accept different knowledge as it is built
-on facts, data and evidence.
-
-**Willingness to learn:** Science is a lifelong journey.  Passion for
-intellectual development: we build paths to enlightenment.
-
-## What we do?
-
-We believe in developing rational, science-based and sustainable open solutions
-to humanity’s problems. We do this by offering complete computational
-technologies aimed at building knowledge about biological systems of interest.
-Our goal is to support the pharmaceutical industry in the intelligent drug
-design process to enable innovative treatments for those who need them.

--- a/index.md
+++ b/index.md
@@ -20,9 +20,9 @@ binding free energies for networks of molecular systems.
 
 ### DRUG DESIGN AND DISCOVERY
 
-Our tools are designed with the pharmaceutical lead optimization in mind, and
-we work closely with our board members in industry to develop tools that meet
-the needs of real-world users.
+Our tools are designed with pharmaceutical lead optimization in mind, and we
+work closely with our board members in industry to develop tools that meet the
+needs of real-world users.
 
 
 OpenFE is hosted by the [Open Molecular Software Foundation](https://omsf.io).


### PR DESCRIPTION
This proposes a split between the landing page and the about page. I also rewrote the sort of bullet-point definitions of the landing page to be less like definitions and more like advertising copy. Please check those to be sure they're accurate.

I'm not fond of the stuff in "About." (1) It doesn't feel like it is intended for the audience of this website (potential funders); instead it seems more like internal corporate culture identity stuff. (2) It is extremely generic and vague -- sounds like it was taken straight from some broad OMSF mission statement; nothing OpenFE-specific.