### PR TITLE
Add "Try It Online" button to landing page

### DIFF
--- a/_sass/customizations.scss
+++ b/_sass/customizations.scss
@@ -47,6 +47,10 @@ h2, h3 {
     background: var(--other-blue);
 }
 
+.button.cta.alt a:hover {
+    color: var(--badass-blue);
+}
+
 .bottom-cta h2 {
     color: #FFF;
 }

--- a/index.html
+++ b/index.html
@@ -40,6 +40,9 @@ bottom: >-
   <div class="text-container">
     <h1>{{ page.title }}</h1>
     <p class="subtext">{{ page.description | markdownify }}</p>
+    <div class="cta button alt">
+        <a href="http://try.openfree.energy">Try It Online</a>
+    </div>
     {% if page.hero %}
     <div>
       <img src="{{ page.hero.src }}" alt="{{ page.hero.alt }}" />


### PR DESCRIPTION
Links to http://try.openfree.energy:

<img width="1359" alt="image" src="https://user-images.githubusercontent.com/8178546/165982840-88118afd-e192-4e2d-9e57-a87510c172ca.png">

Open to other phrasing -- this is specifically trying our flagship code `openfe`, which is distinct from Open Free Energy as a project. But I think we want a link to that binder notebook in that location on the landing page.

Resolves #26.