### PR TITLE
partners-2022-10-31

### DIFF
--- a/about.md
+++ b/about.md
@@ -32,7 +32,7 @@ The Open Free Energy Fund, managed by OMSF, receives contributions from industri
 - [Confo Therapeutics](https://www.confotherapeutics.com/)
 - [Eli Lilly](https://www.lilly.com/)
 - [Exscientia](https://www.exscientia.ai/)
-- [Genentech, Inc](https://www.gene.com/)
+- [Genentech, a member of the Roche Group](https://www.gene.com/)
 - [GSK](https://www.gsk.com/en-gb/)
 - [Interline Therapeutics](https://www.interlinetx.com/)
 - [Janssen Pharmaceutica NV](https://www.janssen.com/)


### PR DESCRIPTION
From 'Genentech, Inc' to 'Genentech, a member of the Roche Group'.