### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,82 @@
 # Website for OpenFreeEnergy
 
-The get this started within a [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#regular-installation) environment, first create an environment from the included `environment.yml` file (`conda env create --file environment.yml`).
-Before following the next steps, be sure to active your environment with `conda activate ofe-website`.
-Then you will need to run `bundle install`. 
-From there, you can launch a local server using `bundle exec jekyll serve`. 
-Use the `--watch` argument to `jekyll serve` if you want website to automatically update as you make changes.
+To build the website locally, you'll create a
+[conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html#regular-installation)
+environment and install the website's bundle within that. Once you have conda
+installed, and this repo cloned, the commands to run (from within the root
+directory of this repo) are:
+
+```bash
+conda env create --file environment.yml
+conda activate ofe-website
+bundle install
+```
+
+From there you can launch a local web server with
+
+```bash
+bundle exec jekyll serve
+```
+
+or, if you want to have the website automatically update as you make changes:
+
+```bash
+bundle exec jekyll serve --watch
+```
+
+Contents:
+
+* [Adding news items](#adding-news-items)
+* [Adding new team members](#adding-new-team-members)
+* [Adding new packages to our projects
+page](#adding-new-packages-to-our-projects-page)
+* [Tracking upstream changes](#tracking-upstream-changes)
+
+## Adding news items
+
+News items are stored in the `_posts/` directory. Each item is a file. That
+file must be named in the format `YYYY-MM-DD-TITLE` where `YYYY-MM-DD` gives
+the year month and day for the post. With this, it is possible to backdate posts.
+<!-- TODO: mention URL; but maybe after adjusting it -->
+
+The file will is Markdown format with YAML frontmatter. The YAML frontmatter
+should include the following:
+
+* `layout: post`: News items should use the `post` layout.
+* `title`: The title of the post.
+* `categories`: space-separated list of categories. Categories we encourage are
+  names of specific software packages (e.g., `gufe`, `openfe`, `lomap`) and
+  types of news item (e.g., `releases`, `presentations`, `hirings`).
+
+## Adding new team members
+
+Each team member has a file that is just a markdown file with YAML frontmatter.
+Only the frontmatter is filled in. The frontmatter includes the following fields:
+
+* `name`: Full name as you want it on the website
+* `position`: Title at OpenFreeEnergy
+* `image_path`: URL or path to an image. We frequently use our GitHub avatars
+  (in which case this should be the whole https URI). If using a file, place it
+  in the `assets/images/team/` directory. In that case, note that the
+  `image_path` should have a preceding slash (i.e.,
+  `/assets/images/team/image.jpg`)
+* `github`: You GitHub username
+* `scholar` [optional]: A link to your Google Scholar profile. Should include
+  everything that comes after `https://scholar.google.com/` in your profile's
+  URL. Leave this blank if you don't want to include your Google Scholar link.
+* `blurb`: A brief paragraph describing yourself.
+
+You can copy `_team/_defaults.md` to get a template. You can see the rendered
+versions at https://openfree.energy/team/.
+
+
+## Adding new packages to our projects page
+
+The details for these are in files in `_projects/`. Make a copy of
+`_defaults.md`. Note that these are markdown files with YAML frontmatter
+(although all you do is fill in the YAML). Fill in each of the fields. `role`
+can be one of `flagship`, `developers`, `maintainers`. Within each role,
+projects are listed alphabetically by filename.
 
 ## Tracking upstream changes
 
@@ -28,31 +100,4 @@ You can find the location of the installed file with:
 bundle info --path jekyll-theme-hydra
 ```
 
-## Adding new packages to our projects page
 
-The details for these are in files in `_projects/`. Make a copy of
-`_defaults.md`. Note that these are markdown files with YAML frontmatter
-(although all you do is fill in the YAML). Fill in each of the fields. `role`
-can be one of `flagship`, `developers`, `maintainers`. Within each role,
-projects are listed alphabetically by filename.
-
-## Adding new team members
-
-Each team member has a file that is just a markdown file with YAML frontmatter.
-Only the frontmatter is filled in. The frontmatter includes the following fields:
-
-* `name`: Full name as you want it on the website
-* `position`: Title at OpenFreeEnergy
-* `image_path`: URL or path to an image. We frequently use our GitHub avatars
-  (in which case this should be the whole https URI). If using a file, place it
-  in the `assets/images/team/` directory. In that case, note that the
-  `image_path` should have a preceding slash (i.e.,
-  `/assets/images/team/image.jpg`)
-* `github`: You GitHub username
-* `scholar` [optional]: A link to your Google Scholar profile. Should include
-  everything that comes after `https://scholar.google.com/` in your profile's
-  URL. Leave this blank if you don't want to include your Google Scholar link.
-* `blurb`: A brief paragraph describing yourself.
-
-You can copy `_team/_defaults.md` to get a template. You can see the rendered
-versions at https://openfree.energy/team/.


### PR DESCRIPTION
- [x] rewrite install/setup info
- [x] add TOC for topics in readme
- [x] add how-to on adding news items
- [x] reorder topics to put less common tasks lower

This was in response to some slack discussion that it would be good to add more news items. The main purpose was adding the new how-to section on that; the rest was just clean-up on the side.