### PR TITLE
Use empty string to avoid loading GA script

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ title: OpenFreeEnergy
 url: "https://openfree.energy/"
 baseurl:
 remote_theme: CloudCannon/hydra-jekyll-template
-google_analytics_key:
+google_analytics_key: ""  # must be empty string to disable (theme issue)
 google_maps_javascript_api_key:
 disqus_shortname:
 


### PR DESCRIPTION
Resolves #54.

In another episode of "this theme is not designed very well," apparently leaving the `google_analytics_key` blank (or not listing it in `_config.yml` at all) is not enough to disable it; presumably because it parses to `None` [instead of `""`](https://github.com/CloudCannon/hydra-jekyll-template/blob/c7f5728643ffb3904d50136cc89762c247030ff7/_layouts/default.html#L14). So we need to give the literal empty string instead.

Note that to test this locally, you need to run as:

```bash
JEKYLL_ENV=production bundle exec jekyll serve
```

Without the `JEKYLL_ENV` variable set to `"production"`, you won't generate the GA script block in the version without this fix (so you get a false positive that any attempt to fix this works).

Credit to @mikemhenry for finding the issue as well as the relevant (annoyingly wrong) line in the theme. I'll go ahead and also propose a fix upstream (keeping in mind that the [empty string is actually "truthy" in liquid](https://shopify.github.io/liquid/basics/truthy-and-falsy/)); I think that this ugly fix is better than us maintaining a local override of the more general fix.