### PR TITLE
[WIP] Ecosystem registry infrastructure

### DIFF
--- a/README_ecosystem_plugins.md
+++ b/README_ecosystem_plugins.md
@@ -1,0 +1,56 @@
+# Managing the ecosystem catalog
+
+A subset of this website is devoted to providing a catalog of software that
+makes up the broader Open Free Energy ecosystem. This is intended to be a
+central clearinghouse where users can find different modular tools that can be
+plugged into an Open Free Energy workflow. This page documents that part of the
+website.
+
+## Adding a new catalog entry
+
+External contributors are most likely to want to add a new catalog entry,
+representing some useful code that they have created and wish to share. Adding
+new entries is intended to be as easy as possible.
+
+Basically, all you need to do is fork and clone this repo, and add a new item
+under the `_ecosystem/` directory. This will be a Markdown file with YAML
+frontmatter.  Copy the `_ecosystem/_defaults.md` file to get a template that
+you can work from.
+
+Add that file in a branch on your fork, and make a pull request to have your
+new entry added to the catalog!
+
+NOTE: Each ecosystem catalog entry should fit into exactly one category. If
+you've created a package that involves tools from multiple categories, please
+create multiple catalog entries. One pull request may contain as many catalog
+entries as you would like to add.
+
+## Customizing ecosystem configuration
+
+The general idea  here is that catalog entries represent different "categories"
+of object, with the objects within a category being modular replacements for
+each other. As an example, "protocol" is one of the categories for Open Free
+Energy.
+
+Details of the ecosystem configuration are in the `_config.yaml` for the site.
+In particular, custom configuration the ecosystem tools are under the
+`ecosystem_catalog` top-level heading. This allows you to change, e.g., the
+allowed categories.
+
+Some aspects of configuration are based on Jekyll's standard configuration
+tools. In particular, note that `ecosystem` is one the Jekyll `collections`,
+and note that we can set the default layout for ecosystem entries within the
+standard `defaults` configuration heading.
+
+## Changing the presentation of catalog entries
+
+Catalog entries are shown in two different styles:
+
+1. Full-page mode, where a full web page is dedicated to each entry. This is
+   intended to provide sufficient details for a reader to learn more about the
+   entry. You can customize this mode in `_layouts/ecosystem-entry.html`. 
+2. Summary mode, where a brief summary of each entry is provided, e.g., as part
+   of a list of other catalog entries. You can customize this mode in
+   `_includes/ecosystem-summary.html`.
+
+You can, of course, always create a custom page that loops over the 

--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,14 @@ collections:
   projects:
   jobs:
     output: true
+  ecosystem:
+    output: true
+
+ecosystem_catalog:
+  category_labels:
+    atommapper: "Atom Mappers"
+    networkplanner: "Network Planners"
+    protocol: "Protocols"
 
 paginate: 10
 paginate_path: "/news/:num/"
@@ -60,6 +68,11 @@ defaults:
       type: "jobs"
     values:
       layout: "job"
+  - scope:
+      path: ""
+      type: "ecosystem"
+    values:
+      layout: "ecosystem-entry"
   - scope:
       path: ""
     values:

--- a/_ecosystem/_default.md
+++ b/_ecosystem/_default.md
@@ -1,0 +1,19 @@
+---
+name: <NAME OF ENTRY>
+category: <CATEGORY>
+developers: <DEVELOPERS AS A STRING>
+source: <URL FOR SOURCE CODE>
+license: <STRING NAME OF LICENSE>
+summary: >-
+  <ADD SUMMARY HERE>
+
+### FOLLOWING ARE OPTIONAL
+# docs: <URL FOR DOCUMENTATION>
+# contact: <EMAIL FOR CONTACT>
+# publications:
+#   - <LIST OF DOI>
+# thumbnail:
+#   src: <URL FOR THUMBNAIL IMAGE>
+#   alt: <ALT TEXT FOR THUMBNAIL>
+---
+<FREE FORM LONG DESCRIPTION HERE>

--- a/_ecosystem/example.md
+++ b/_ecosystem/example.md
@@ -1,0 +1,11 @@
+---
+name: An example plugin
+category: atommapper
+developers: Those cool cats at OpenFE
+source: https://github.com/openfreeenergy/openfreeenergy.github.io
+license: MIT
+summary: >-
+  An awesome OpenFE plugin
+---
+
+Now let me tell you all the awesome details about this plugin.

--- a/_ecosystem/example2.md
+++ b/_ecosystem/example2.md
@@ -1,0 +1,11 @@
+---
+name: Another example plugin
+category: protocol
+developers: more cool cats at OpenFE
+source: https://github.com/openfreeenergy/openfreeenergy.github.io
+license: MIT
+summary: >-
+  A protocol plugin
+---
+
+

--- a/_ecosystem/kartograf.md
+++ b/_ecosystem/kartograf.md
@@ -1,0 +1,13 @@
+---
+name: Kartograf
+category: atommapper
+developers: Ben Ries and other OpenFE people
+source: https://github.com/openfreeenergy/kartograf
+license: MIT
+summary: >-
+  Kartograf is a 3D-first atom mapper. This allows it to avoid some problems,
+  particularly those around chirality, that can occur with 2D mappers (e.g.,
+  those focused on common substructure.) Ben can expand this a little if he wants.
+---
+
+This is where Ben should write a lot more detail about Kartograf.

--- a/_ecosystem/lomap-mapper.md
+++ b/_ecosystem/lomap-mapper.md
@@ -1,0 +1,36 @@
+---
+name: LOMAP Atom Mapper
+category: atommapper
+developers: Mobley Lab and Open Free Energy
+source: https://github.com/openfreeenergy/Lomap
+license: MIT
+summary: >-
+  The LOMAP atom mapper is based on a maximum common substructure approach to
+  detemine the mapping between two ligands.
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Elit duis tristique sollicitudin
+nibh sit amet. Vitae auctor eu augue ut lectus. Sit amet dictum sit amet justo
+donec enim diam. Id venenatis a condimentum vitae sapien pellentesque habitant
+morbi. Ut eu sem integer vitae justo eget magna fermentum iaculis. Vel orci
+porta non pulvinar neque laoreet suspendisse interdum. Curabitur vitae nunc sed
+velit. Id aliquet risus feugiat in ante metus dictum at. Venenatis cras sed
+felis eget velit aliquet sagittis id. Nibh sed pulvinar proin gravida
+hendrerit. Eget nullam non nisi est. Viverra maecenas accumsan lacus vel
+facilisis volutpat est velit egestas. Lectus vestibulum mattis ullamcorper
+velit sed. Pellentesque elit ullamcorper dignissim cras tincidunt lobortis
+feugiat. Dolor sed viverra ipsum nunc aliquet bibendum enim.
+
+Morbi non arcu risus quis varius quam quisque id. Dui sapien eget mi proin sed.
+Nunc vel risus commodo viverra maecenas accumsan lacus. Condimentum mattis
+pellentesque id nibh tortor id aliquet lectus. In metus vulputate eu
+scelerisque felis imperdiet proin. Id velit ut tortor pretium viverra
+suspendisse potenti. Ut pharetra sit amet aliquam id. In fermentum et
+sollicitudin ac orci phasellus egestas tellus. Ultricies mi eget mauris
+pharetra. Nunc id cursus metus aliquam. Nunc non blandit massa enim nec dui
+nunc mattis. Mattis aliquam faucibus purus in massa tempor nec feugiat nisl.
+Lacus sed turpis tincidunt id aliquet risus feugiat in ante. Nisl purus in
+mollis nunc sed. In hac habitasse platea dictumst quisque sagittis. Neque
+ornare aenean euismod elementum nisi quis eleifend. Vel quam elementum pulvinar
+etiam non quam lacus suspendisse.

--- a/_includes/ecosystem-summary.html
+++ b/_includes/ecosystem-summary.html
@@ -1,0 +1,24 @@
+{% comment %}
+This is the include file for a catalog entry summary card. Style can be done
+in SASS/CSS. In this implementation, there's a paragraph for the entry
+name (which links to the entry's full page), a paragraph for the developers,
+a paramgraph for the entry's summary, and a list of bullet points for the
+license and anything else we might want to add to the summary.
+{% endcomment %}
+
+<div class="ecosystemSummary" id="ecosystem-{{ include.entry.name }}">
+    <p class="ecosystemSummaryTitle">
+        <a href="{{ include.entry.url }}">{{ include.entry.name }}</a>
+    </p>
+    <p class="ecosystemSummaryAuthor">
+        {{ include.entry.developers }}
+    </p>
+    <p class="ecosystemSummarySummary">
+        {{ include.entry.summary }}
+    </p>
+    <!-- TODO: add this in later, once there are more things to include
+    <ul class="ecosystemSummaryExtras">
+        <li>{{ include.entry.license }}</li>
+    </ul>
+    -->
+</div>

--- a/_layouts/ecosystem-entry.html
+++ b/_layouts/ecosystem-entry.html
@@ -1,0 +1,27 @@
+---
+layout: page
+---
+
+<div class="ecosystemEntry">
+
+<div class="ecosystemDetailsBox">
+<dl>
+    <dt>Developers</dt>
+    <dd>{{ page.developers }}</dd>
+    <dt>Source code</dt>
+    <!-- TODO: extract GitHub links to make prettier -->
+    <dd><a href="{{ page.source }}">{{ page.source }}</a></dd>
+    <dt>License</dt>
+    <dd>{{ page.license }}</dd> <!-- TODO: link known licenses -->
+</dl>
+{{ page.summary | markdownify }}
+</div>
+
+<p><span class="ecosystemCategoryLabel">
+    {% assign label = site.ecosystem_catalog.category_labels[page.category] %}
+    {{ label | upcase }}
+</span></p>
+
+{{ page.content | markdownify }}
+
+</div>

--- a/_sass/customizations.scss
+++ b/_sass/customizations.scss
@@ -105,3 +105,82 @@ code {
 }
 
 
+// for the ecosystem summary entries (e.g., ecosystem.html)
+ul.ecosystemSummaryList {
+    display: flex;
+    flex-flow: row wrap;
+    gap: 10px;
+}
+
+li.ecosystemSummaryItem {
+    display: inline-block;
+    flex: 0 0 45%;
+    vertical-align: top;
+    border: 1px solid var(--other-blue);
+    padding: 1ex;
+    box-shadow: 2px 2px 2px var(--beastly-grey);
+}
+
+div.ecosystemSummary {
+    float: left;
+    margin-bottom: 0px;
+    margin-block-start: 0px;
+    height: 100%;
+}
+
+.ecosystemSummary p {
+    margin-bottom: 10px;
+    line-height: normal;
+}
+
+p.ecosystemSummaryTitle {
+    font-size: 1.0em;
+    font-weight: 600;
+    margin-top: 5px;
+}
+
+p.ecosystemSummaryAuthor {
+    font-size: 0.5em;
+    font-weight: 300;
+}
+
+p.ecosystemSummarySummary {
+    font-size: 0.8em;
+    font-weight: 300;
+    line-height: 1.1em;
+}
+
+ul.ecosystemSummaryExtras {
+    font-size: 0.5em;
+    font-weight: 300;
+}
+
+ul.ecosystemSummaryExtras li {
+    display: inline-block;
+}
+
+// switch to 1-column layout for mobile
+@media screen and (max-width: 639px) {
+    ul.ecosystemSummaryList {
+        flex-flow: column nowrap;
+    }
+}
+
+
+// for the ecosystem entries (individual pages)
+.ecosystemEntry {
+    overflow: auto;
+}
+
+div.ecosystemDetailsBox {
+    width: 45%;
+    float: right;
+    color: var(--beastly-grey);
+    border: 1px solid var(--other-blue);
+    padding: 1ex;
+    margin: 1ex;
+}
+
+div.ecosystemDetailsBox p {
+    font-size: 1.0em;
+}

--- a/ecosystem.html
+++ b/ecosystem.html
@@ -1,0 +1,22 @@
+---
+title: Ecosystem
+permalink: /ecosystem/
+description: >-
+  Other tools in the OpenFE ecosystem.
+---
+
+{% assign grouped = site.ecosystem | group_by:"category" %}
+{% for category in site.ecosystem_catalog.category_labels %}
+<h3>{{ category[1] }}</h3>
+  {% assign cat_plugins = grouped | where: "name", category[0] %}
+  {% comment %}
+  There can only be one object in grouped with the appropriate name, so we
+  take cat_plugins[0]. We loop over them as li (as opposed to creating a
+  structure of divs) because that's better for screenreaders.
+  {% endcomment %}
+  <ul class="ecosystemSummaryList">
+    {% for plugin in cat_plugins[0].items %}
+    <li class="ecosystemSummaryItem">{% include ecosystem-summary.html entry=plugin %}</li>
+    {% endfor %}
+  </ul>
+{% endfor %}


### PR DESCRIPTION
This PR will add in the registry page for tools in the OpenFE ecosystem. The main idea is that we want a centralized listing of plugins/packages in the OpenFE ecosystem, so that we can help users find contributions (both external and internal).

Users would browse the ecosystem page, and find the tool they want. In addition to a short summary on a collective ecosystem page, each tool will have its own full page, containing a box with details and a free-form documentation. Contributors can add their tool to the ecosystem page by adding a simple document (Markdown with YAML front matter) to this repository via pull request.


Screenshots of initial versions of each (first at 1920x1080, then at 414x736 (iPhone 8+), all generated with Safari's responsive design mode):
<img width="1065" alt="Main page, desktop" src="https://github.com/OpenFreeEnergy/openfreeenergy.github.io/assets/8178546/93711022-9417-4921-98e9-d8bd24bb8217">
<img width="1059" alt="Plugin page, desktop" src="https://github.com/OpenFreeEnergy/openfreeenergy.github.io/assets/8178546/fb9e9aa8-7bc7-47c2-bd83-33da66f55fe0">

<img width="325" alt="Main page, mobile" src="https://github.com/OpenFreeEnergy/openfreeenergy.github.io/assets/8178546/562cfabd-057c-4593-927a-6e87f4de3ab0">
<img width="326" alt="Plugin page, mobile" src="https://github.com/OpenFreeEnergy/openfreeenergy.github.io/assets/8178546/c5d853ad-95ac-41c3-9985-22e0e66fd970">

Inspiration largely taken from [PyPI](https://pypi.org), [MDAKits](https://mdakits.mdanalysis.org), and the [E-CAM software library](https://e-cam.readthedocs.io/en/latest/). Target for this PR is a basic ecosystem setup, with a set of fields to include in the YAML front matter.

Questions to resolve (feedback desired):

* **Are pages per-package or per-plugin?** Example: LOMAP contains plugins for both an atom mapper and a network planner. Do we add a page for each (current implementation) or just a single page for all things LOMAP? A page for each is more work for a contributor, but (IMO) a better experience for a website visitor (at least, with straightforward implementation), which is why I've started with that approach.
* **What fields do we want to include in the YAML front matter?** I've added a few obvious ones, but there's definitely room for discussion on what should be required vs. optional.
* **How do we want to handle authors?** I don't see a perfect solution here. It would be great be able to have a page for each author, showing all their contributions, but that needs some kind of author registration (or else it is very error prone). For now, contributor name is just a string, and we don't have a way to group by contributor.
* **Do we want to enable some kind of ordering?** For example, we might want all tools maintained by OpenFE to come first.

Outside scope of this PR, but planned future work:

* Script to generate a draft of the contribution for a given plugin based on package metadata (probably obtained from an installed package with `importlib.metadata`; other options are to parse `pyproject.toml`/`setup.cfg` or to obtain from PyPI JSON files.)
* Fill in content for the current tools in the ecosystem.
* (Possible future work) It would be cool if there were more ways to explore the existing ecosystem tools. For example, I can imagine wanting to see things sorted by newest additions, or to see packages that have recently updated or recently released. External information like that could be probably be scraped in a nightly cron job.

So far, this isn't actually linked from the navigation or from any pages. However, the ecosystem landing page can be seen at the `ecosystem/` path when you run locally. I think that linking it from the main site should be beyond the scope of this PR (wait until we have some real content).