### PR TITLE
Improve our 404 error page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,10 +1,11 @@
 ---
 permalink: /404.html
-layout: default
+layout: page
+sitemap: false
 ---
 
 <style type="text/css" media="screen">
-  .container {
+  .container-404 {
     margin: 10px auto;
     max-width: 600px;
     text-align: center;
@@ -17,7 +18,7 @@ layout: default
   }
 </style>
 
-<div class="container">
+<div class="container-404">
   <h1>404</h1>
 
   <p><strong>Page not found :(</strong></p>


### PR DESCRIPTION
Our current 404 page looks terrible:

<img width="1354" alt="image" src="https://github.com/OpenFreeEnergy/openfreeenergy.github.io/assets/8178546/ef647a03-17ec-42d3-9a9c-4901979c5cd0">

I think the 404.html was taken from a different theme, and it conflicts with our theme. This PR makes our 404 a little less horrible:

<img width="1354" alt="image" src="https://github.com/OpenFreeEnergy/openfreeenergy.github.io/assets/8178546/ab4c503c-a025-44e4-a2bd-f2fbc2027968">

It still isn't as good as [this one](https://acm.illinois.edu/404), though.