### PR TITLE
announce stable release, reinstate news

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,6 +10,10 @@
   link: /team/
   new_window: False
   highlight: False
+- name: News
+  link: /news/
+  new_window: False
+  highlight: False
 - name: Getting involved
   link: /getting_involved/
   new_window: False

--- a/_posts/2024-05-03_stable-release.md
+++ b/_posts/2024-05-03_stable-release.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title: "OpenFE 1.0: Stable release!"
+categories: openfe release
+---
+
+We are thrilled to announce the release of OpenFE v1.0, an open source Python package for performing alchemical free energy calculations.  OpenFE is the flagship package of the Open Free Energy project, a nonprofit pre-competitive consortium hosted by the Open Molecular Software Foundation (OMSF).
+
+Who is it for? We have a wide user base ranging from academics to industry partners in the pharmaceutical and biotech sectors. Whether you're looking for a simple, ready-to-go workflow to carry out your binding free energy calculations or you're a method developer or a power user who wants full control, OpenFE is your toolbox. It provides you with an environment of interchangeable tools and multiple ways to import your existing data and export results. OpenFE can be used either in Python or through a streamlined CLI. 
+Let's highlight some current features:
+
+Relative Binding/Hydration Free Energy Calculations using the Hybrid Topology approach, including the capability of charge changing transformations
+Absolute Hydration Free Energy Calculations
+“Vanilla” Molecular Dynamics (MD) simulations
+Automated setup approaches for the calculations
+Automated analysis of results
+
+And that's not all! OpenFE is constantly evolving. We will continue to implement new features and improve our software. We are always eager to receive feedback from you.
+So, let us know what you think! You can try it out in your browser at [](http://try.openfree.energy). Happy exploring Alchemical Free Energies with OpenFE!
+
+[GitHub](https://github.com/OpenFreeEnergy/openfe)
+[Documentation](https://docs.openfree.energy/en/stable/)


### PR DESCRIPTION
I can't get jekyll to build on my laptop, so I'm pushing blind. Please check that it renders (with the News page) before merging