### PR TITLE
Redirect /roadmap to the OpenFE wiki roadmap page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -85,6 +85,9 @@ plugins:
   - jekyll-feed
   - jekyll-paginate
 
+include:
+  - _redirects
+
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+/roadmap https://github.com/OpenFreeEnergy/openfe/wiki/OpenFE-Roadmap 301
+/roadmap/ https://github.com/OpenFreeEnergy/openfe/wiki/OpenFE-Roadmap 301

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,8 +1,0 @@
----
-layout: page
-title: Roadmap
-description: What we've done and where we're going.
-permalink: /roadmap/
----
-
-![OpenFE roadmap diagram](/assets/images/roadmap.svg)


### PR DESCRIPTION
Removes the orphaned roadmap.md page (no internal links pointed to it) in favor of a 301 redirect to the maintained roadmap on the openfe wiki.

Claude told me how to set up the redirect. I don't understand this aspect of http, and it had to look up something from the cloudflare deployment guide, so I'm a little cautious. But the file change to config.yml doesn't look dangerous, and we can verify it works in the deployment preview workflow.