### PR TITLE
add link to github discussions under Get Involved

### DIFF
--- a/get_involved.md
+++ b/get_involved.md
@@ -9,7 +9,7 @@ There are three ways to get involved with Open Free Energy:
  - Academic research labs can collaborate through membership in our Technical Advisory Council.
  - Individuals can contribute code on [github](https://github.com/OpenFreeEnergy).
 
-To get in touch, please email us at `OpenFreeEnergy@omsf.io`
+To get in touch, please email us at `OpenFreeEnergy@omsf.io` or [join the discussion on github](https://github.com/orgs/OpenFreeEnergy/discussions)
 
 
 Joining the Consortium

--- a/get_involved.md
+++ b/get_involved.md
@@ -9,7 +9,7 @@ There are three ways to get involved with Open Free Energy:
  - Academic research labs can collaborate through membership in our Technical Advisory Council.
  - Individuals can contribute code on [github](https://github.com/OpenFreeEnergy).
 
-To get in touch, please email us at `OpenFreeEnergy@omsf.io` or [join the discussion on github](https://github.com/orgs/OpenFreeEnergy/discussions)
+To get in touch, please email us at `OpenFreeEnergy@omsf.io` or [join the discussion on github](https://github.com/orgs/OpenFreeEnergy/discussions).
 
 
 Joining the Consortium


### PR DESCRIPTION
This is the MVP: a link under Get Involved. David Dotson had proposed a button on the front page, but IIRC we tried doing two buttons on the top of that page before and it broke some formatting.